### PR TITLE
Added phase to status of managedocs

### DIFF
--- a/api/v1alpha1/managedocs_types.go
+++ b/api/v1alpha1/managedocs_types.go
@@ -33,6 +33,18 @@ const (
 	ReconcileStrategyStrict ReconcileStrategy = "strict"
 )
 
+// Phase represents the phase of addon
+type Phase string
+
+const (
+	// PhaseReady is used when deployer is ready for reconcile operations
+	PhaseReady Phase = "Ready"
+	// PhaseConfiguring is used when deployer is running reconcile operations
+	PhaseConfiguring Phase = "Configuring"
+	// PhaseUninstalling is used when uninstall is initiated
+	PhaseUninstalling Phase = "Uninstalling"
+)
+
 // ManagedOCSSpec defines the desired state of ManagedOCS
 type ManagedOCSSpec struct {
 	ReconcileStrategy ReconcileStrategy `json:"reconcileStrategy,omitempty"`
@@ -61,6 +73,7 @@ type ComponentStatusMap struct {
 type ManagedOCSStatus struct {
 	ReconcileStrategy ReconcileStrategy  `json:"reconcileStrategy,omitempty"`
 	Components        ComponentStatusMap `json:"components"`
+	Phase             Phase              `json:"phase"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/ocs.openshift.io_managedocs.yaml
+++ b/config/crd/bases/ocs.openshift.io_managedocs.yaml
@@ -74,12 +74,16 @@ spec:
                 - prometheus
                 - storageCluster
                 type: object
+              phase:
+                description: Phase represents the phase of addon
+                type: string
               reconcileStrategy:
                 description: ReconcileStrategy represent the action the deployer should
                   take whenever a recncile event occures
                 type: string
             required:
             - components
+            - phase
             type: object
         type: object
     served: true

--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -380,6 +380,14 @@ func (r *ManagedOCSReconciler) reconcilePhases() (reconcile.Result, error) {
 	// We are checking the uninstallation condition before getting the component status
 	// to mitigate scenarios where changes to the component status occurs while the uninstallation logic is running.
 	initiateUninstall := r.checkUninstallCondition()
+
+	// Set the phase of managedocs
+	if initiateUninstall {
+		r.managedOCS.Status.Phase = v1.PhaseUninstalling
+	} else {
+		r.managedOCS.Status.Phase = v1.PhaseConfiguring
+	}
+
 	// Update the status of the components
 	r.updateComponentStatus()
 
@@ -490,6 +498,11 @@ func (r *ManagedOCSReconciler) reconcilePhases() (reconcile.Result, error) {
 
 	} else if initiateUninstall {
 		return ctrl.Result{}, r.removeOLMComponents()
+	}
+
+	// Set the phase of managedocs
+	if !initiateUninstall {
+		r.managedOCS.Status.Phase = v1.PhaseReady
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
Phase of ManagedOCS can have three values, first value is Ready when the deployer is Ready to perform the reconcile operations but is not performing the operations.
The second value is Configuring, when the deployer is performing reconcile operations and making changes to the resources. 
The third value is Uninstalling, when the uninstallation of the addon is initiated the deployer will enter uninstall phase.

Signed-off-by: bindrad <dbindra@redhat.com>