### PR TITLE
Changed the subject of SendGrid mails

### DIFF
--- a/templates/alertmanagerconfig.go
+++ b/templates/alertmanagerconfig.go
@@ -122,7 +122,7 @@ var AlertmanagerConfigTemplate = promv1a1.AlertmanagerConfig{
 				AuthPassword: &corev1.SecretKeySelector{Key: "", LocalObjectReference: corev1.LocalObjectReference{Name: ""}},
 				Headers: []promv1a1.KeyValue{{
 					Key:   "subject",
-					Value: `{{ range .Alerts.Firing }}{{ range .Labels.SortedPairs }}{{ if eq .Name "severity" }}{{ .Value | title }}{{ end }}{{ end }}{{ end }} alert! Action required on your managed OpenShift cluster`,
+					Value: `OpenShift Data Foundation Managed Service notification, Action required on your managed OpenShift cluster!`,
 				}},
 			},
 			},


### PR DESCRIPTION
The subject is changed because the previous subject didn't give any information about ODF managed service and previously subject started with Critical Alert or Warning Alert which doesn't make sense to the customers. By changing the subject this BZ will be solved as well https://bugzilla.redhat.com/show_bug.cgi?id=2009694

Signed-off-by: bindrad <dbindra@redhat.com>