### PR TITLE
Added clicktracking=off attribute to HTML a tag of SendGrid mails

### DIFF
--- a/templates/customernotification.html
+++ b/templates/customernotification.html
@@ -40,7 +40,7 @@
         {{ end }}
         </strong>
         <br>
-        If you have any questions, please <a href="https://access.redhat.com/support/contact/technicalSupport/">contact us</a>. Review the <a href="https://access.redhat.com/support/policy/support_process">support process</a> for guidance on working with Red Hat support.
+        If you have any questions, please <a clicktracking=off href="https://access.redhat.com/support/contact/technicalSupport/">contact us</a>. Review the <a clicktracking=off href="https://access.redhat.com/support/policy/support_process">support process</a> for guidance on working with Red Hat support.
         <br><br>
         Thank you for choosing Red Hat OpenShift Data Foundation,
         <br>


### PR DESCRIPTION
The links in SendGrid emails won't redirect to SendGrid server, it'll directly redirect to the actual href link in the HTML a tag. This will help to resolve the attached bz: https://bugzilla.redhat.com/show_bug.cgi?id=2010699
Link to click tracking documentation: https://docs.sendgrid.com/ui/account-and-settings/tracking

Signed-off-by: bindrad <dbindra@redhat.com>