### PR TITLE
Update dependency to v4.10.0 and changes to setting noobaa deployment to 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,11 @@ run: generate fmt vet manifests export_env_vars
 	kubectl create secret generic ${ADDON_NAME}-smtp -n ${NAMESPACE} --from-literal host="smtp.sendgrid.net" --from-literal password="test-key" --from-literal port="587" \
 	--from-literal username="apikey" --dry-run=client -oyaml | kubectl apply -f -
 	kubectl create configmap rook-ceph-operator-config -n ${NAMESPACE} --dry-run=client -oyaml | kubectl apply -f -
-	echo -e "apiVersion: operators.coreos.com/v1alpha1" \
+	for i in ocs-operator-0.1 mcg-operator-0.1; do \
+		echo -e "apiVersion: operators.coreos.com/v1alpha1" \
 	      "\nkind: ClusterServiceVersion" \
 		  "\nmetadata:" \
-		  "\n  name: ocs-operator-0.1" \
+		  "\n  name: $$i" \
 		  "\n  namespace: ${NAMESPACE}" \
 		  "\nspec:" \
 		  "\n  displayName: ocs operator" \
@@ -86,7 +87,8 @@ run: generate fmt vet manifests export_env_vars
 		  "\n            spec:" \
 		  "\n              containers:" \
 		  "\n              - name: test" \
-		  "\n    strategy: deployment" | kubectl apply -f -
+		  "\n    strategy: deployment" | kubectl apply -f -; \
+	 	done
 	go run ./main.go
 
 # Install CRDs into a cluster

--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -5,5 +5,5 @@ dependencies:
     version: "4.8.0"
 - type: olm.package
   value:
-    packageName: ocs-operator
-    version: "4.8.6"
+    packageName: odf-operator
+    version: "4.10.0"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -175,6 +175,14 @@ var _ = BeforeSuite(func(done Done) {
 	ocsCSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs = getMockOCSCSVDeploymentSpec()
 	Expect(k8sClient.Create(ctx, ocsCSV)).ShouldNot(HaveOccurred())
 
+	// Create a mock MCG CSV
+	mcgCSV := &opv1a1.ClusterServiceVersion{}
+	mcgCSV.Name = mcgOperatorName
+	mcgCSV.Namespace = testPrimaryNamespace
+	mcgCSV.Spec.InstallStrategy.StrategyName = "test-strategy"
+	mcgCSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs = getMockMCGCSVDeploymentSpec()
+	Expect(k8sClient.Create(ctx, mcgCSV)).ShouldNot(HaveOccurred())
+
 	// Create the ManagedOCS resource
 	managedOCS := &v1.ManagedOCS{}
 	managedOCS.Name = managedOCSName
@@ -255,6 +263,32 @@ func getMockOCSCSVDeploymentSpec() []opv1a1.StrategyDeploymentSpec {
 						Containers: []corev1.Container{
 							{
 								Name: "ocs-metrics-exporter",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return deploymentSpec
+}
+
+func getMockMCGCSVDeploymentSpec() []opv1a1.StrategyDeploymentSpec {
+	deploymentSpec := []opv1a1.StrategyDeploymentSpec{
+		{
+			Name: "noobaa-operator",
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"noobaa-operator": "deployment"},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"noobaa-operator": "deployment"},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "noobaa-operator",
 							},
 						},
 					},


### PR DESCRIPTION
Changed dependencies.yaml to bring in odf-operator v4.10.0.
Currently, we are fetching noobaa-operator deployment from ocs-operator csv but now we need to fetch noobaa-operator deployment from mcg-operator csv.

Signed-off-by: bindrad <dbindra@redhat.com>