### PR TITLE
Setting noobaa operator deployment to 0 in mcg-operator csv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,10 @@ run: generate fmt vet manifests export_env_vars
 	kubectl create secret generic ${ADDON_NAME}-smtp -n ${NAMESPACE} --from-literal host="smtp.sendgrid.net" --from-literal password="test-key" --from-literal port="587" \
 	--from-literal username="apikey" --dry-run=client -oyaml | kubectl apply -f -
 	kubectl create configmap rook-ceph-operator-config -n ${NAMESPACE} --dry-run=client -oyaml | kubectl apply -f -
-	echo -e "apiVersion: operators.coreos.com/v1alpha1" \
+	for i in ocs-operator-0.1 mcg-operator-0.1; do echo -e "apiVersion: operators.coreos.com/v1alpha1" \
 	      "\nkind: ClusterServiceVersion" \
 		  "\nmetadata:" \
-		  "\n  name: ocs-operator-0.1" \
+		  "\n  name: $$i" \
 		  "\n  namespace: ${NAMESPACE}" \
 		  "\nspec:" \
 		  "\n  displayName: ocs operator" \
@@ -86,7 +86,7 @@ run: generate fmt vet manifests export_env_vars
 		  "\n            spec:" \
 		  "\n              containers:" \
 		  "\n              - name: test" \
-		  "\n    strategy: deployment" | kubectl apply -f -
+		  "\n    strategy: deployment" | kubectl apply -f -; done
 	go run ./main.go
 
 # Install CRDs into a cluster

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -175,6 +175,14 @@ var _ = BeforeSuite(func(done Done) {
 	ocsCSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs = getMockOCSCSVDeploymentSpec()
 	Expect(k8sClient.Create(ctx, ocsCSV)).ShouldNot(HaveOccurred())
 
+	// Create a mock MCG CSV
+	mcgCSV := &opv1a1.ClusterServiceVersion{}
+	mcgCSV.Name = mcgOperatorName
+	mcgCSV.Namespace = testPrimaryNamespace
+	mcgCSV.Spec.InstallStrategy.StrategyName = "test-strategy"
+	mcgCSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs = []opv1a1.StrategyDeploymentSpec{}
+	Expect(k8sClient.Create(ctx, mcgCSV)).ShouldNot(HaveOccurred())
+
 	// Create the ManagedOCS resource
 	managedOCS := &v1.ManagedOCS{}
 	managedOCS.Name = managedOCSName


### PR DESCRIPTION
In ocs-operator v4.8 the noobaa-operator deployment was in
ocs-operator csv. After pointing the deployer to install
odf-operator v4.10 as the dependency, the noobaa-operator
deployment is in mcg-operator csv.

Signed-off-by: bindrad <dbindra@redhat.com>