### PR TITLE
Increase resource limit and request for ocs-operator pod

### DIFF
--- a/utils/resources.go
+++ b/utils/resources.go
@@ -87,11 +87,11 @@ var resourceRequirements = map[string]corev1.ResourceRequirements{
 	"ocs-operator": {
 		Limits: corev1.ResourceList{
 			"cpu":    resource.MustParse("200m"),
-			"memory": resource.MustParse("120Mi"),
+			"memory": resource.MustParse("200Mi"),
 		},
 		Requests: corev1.ResourceList{
 			"cpu":    resource.MustParse("200m"),
-			"memory": resource.MustParse("120Mi"),
+			"memory": resource.MustParse("200Mi"),
 		},
 	},
 	"rook-ceph-operator": {


### PR DESCRIPTION
OCS-Operator pod goes into oomkilled state multiple times
and eventually to crashloopbackoff state. This was resolved
when the limit and request for the ocs-operator pod was
increased.

Signed-off-by: bindrad <dbindra@redhat.com>