### PR TITLE
Change replacement of the prom CR labels map with just adding the lab…

### DIFF
--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -886,7 +886,7 @@ func (r *ManagedOCSReconciler) reconcilePrometheus() error {
 		}
 
 		desired := templates.PrometheusTemplate.DeepCopy()
-		r.prometheus.ObjectMeta.Labels = map[string]string{monLabelKey: monLabelValue}
+		utils.AddLabel(r.prometheus, monLabelKey, monLabelValue)
 		r.prometheus.Spec = desired.Spec
 		r.prometheus.Spec.Alerting.Alertmanagers[0].Namespace = r.namespace
 		r.prometheus.Spec.AdditionalAlertRelabelConfigs = &corev1.SecretKeySelector{


### PR DESCRIPTION
…el to the current map

This is done to prevent overriding of existing labels and allow other agents to add external labels to the CR

Signed-off-by: nb-ohad <mitrani.ohad@gmail.com>