### PR TITLE
Remove CephMonHighNumberOfLeaderChanges from the pagerduty list

### DIFF
--- a/templates/alertmanagerconfig.go
+++ b/templates/alertmanagerconfig.go
@@ -50,7 +50,6 @@ var pagerdutyAlerts = []string{
 	"CephPGRepairTakingTooLong",
 	"CephMonQuorumAtRisk",
 	"CephMonQuorumLost",
-	"CephMonHighNumberOfLeaderChanges",
 }
 var smtpAlerts = []string{
 	"CephClusterNearFull",
@@ -66,6 +65,9 @@ var smtpAlerts = []string{
 // configuration where an OSD is getting full without the cluster getting full.
 // CephOSDCriticallyFull
 // CephOSDNearFull
+//
+// This indicator has no immediate SRE action item associated with it.
+// "CephMonHighNumberOfLeaderChanges"
 
 var AlertmanagerConfigTemplate = promv1a1.AlertmanagerConfig{
 	Spec: promv1a1.AlertmanagerConfigSpec{


### PR DESCRIPTION
The CephMonHighNumberOfLeaderChanges is not an indicator for an immediate SRE action as such removing it from the PagerDuty list

Signed-off-by: nb-ohad <mitrani.ohad@gmail.com>