### PR TITLE
Adding TLS support to prometheus instance

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,6 +16,16 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclass

--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -39,6 +39,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -68,6 +69,11 @@ const (
 	managedOCSName                         = "managedocs"
 	storageClusterName                     = "ocs-storagecluster"
 	prometheusName                         = "managed-ocs-prometheus"
+	prometheusServiceName                  = "managed-ocs-prometheus-service"
+	servingCertSecretBetaAnnotationKey     = "service.beta.openshift.io/serving-cert-secret-name"
+	servingCertSecretAlphaAnnotationKey    = "service.alpha.openshift.io/serving-cert-secret-name"
+	servingCertConfigMapBetaAnnotationKey  = "service.beta.openshift.io/inject-cabundle"
+	servingCertConfigMapAlphaAnnotationKey = "service.alpha.openshift.io/inject-cabundle"
 	alertmanagerName                       = "managed-ocs-alertmanager"
 	alertmanagerConfigName                 = "managed-ocs-alertmanager-config"
 	dmsRuleName                            = "dms-monitor-rule"
@@ -102,6 +108,8 @@ const (
 	convergedDeploymentType                = "converged"
 	consumerDeploymentType                 = "consumer"
 	providerDeploymentType                 = "provider"
+	servingCertCABundleConfigMapName       = "prometheus-serving-cert-ca-bundle"
+	prometheusServiceSecretName            = "managed-ocs-prometheus-service-secret"
 )
 
 // ManagedOCSReconciler reconciles a ManagedOCS object
@@ -130,6 +138,7 @@ type ManagedOCSReconciler struct {
 	cephIngressNetworkPolicy           *netv1.NetworkPolicy
 	providerAPIServerNetworkPolicy     *netv1.NetworkPolicy
 	prometheus                         *promv1.Prometheus
+	prometheusService                  *corev1.Service
 	dmsRule                            *promv1.PrometheusRule
 	alertmanager                       *promv1.Alertmanager
 	pagerdutySecret                    *corev1.Secret
@@ -143,6 +152,7 @@ type ManagedOCSReconciler struct {
 	reconcileStrategy                  v1.ReconcileStrategy
 	addonParams                        map[string]string
 	onboardingValidationKeySecret      *corev1.Secret
+	servingCertCaBundleConfigMap       *corev1.ConfigMap
 }
 
 // Add necessary rbac permissions for managedocs finalizer in order to set blockOwnerDeletion.
@@ -158,6 +168,7 @@ type ManagedOCSReconciler struct {
 // +kubebuilder:rbac:groups=operators.coreos.com,namespace=system,resources=clusterserviceversions,verbs=get;list;watch;delete;update;patch
 // +kubebuilder:rbac:groups="apps",namespace=system,resources=statefulsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources={persistentvolumes,secrets},verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources={services},verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="storage.k8s.io",resources=storageclass,verbs=get;list;watch
 // +kubebuilder:rbac:groups="networking.k8s.io",namespace=system,resources=networkpolicies,verbs=create;get;list;watch;update
 // +kubebuilder:rbac:groups="network.openshift.io",namespace=system,resources=egressnetworkpolicies,verbs=create;get;list;watch;update
@@ -255,6 +266,7 @@ func (r *ManagedOCSReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&openshiftv1.EgressNetworkPolicy{}).
 		Owns(&netv1.NetworkPolicy{}).
 		Owns(&corev1.Secret{}).
+		Owns(&corev1.Service{}).
 
 		// Watch non-owned resources
 		Watches(
@@ -374,6 +386,10 @@ func (r *ManagedOCSReconciler) initReconciler(ctx context.Context, req ctrl.Requ
 	r.prometheus.Name = prometheusName
 	r.prometheus.Namespace = r.namespace
 
+	r.prometheusService = &corev1.Service{}
+	r.prometheusService.Name = prometheusServiceName
+	r.prometheusService.Namespace = r.namespace
+
 	r.dmsRule = &promv1.PrometheusRule{}
 	r.dmsRule.Name = dmsRuleName
 	r.dmsRule.Namespace = r.namespace
@@ -409,6 +425,10 @@ func (r *ManagedOCSReconciler) initReconciler(ctx context.Context, req ctrl.Requ
 	r.alertRelabelConfigSecret = &corev1.Secret{}
 	r.alertRelabelConfigSecret.Name = alertRelabelConfigSecretName
 	r.alertRelabelConfigSecret.Namespace = r.namespace
+
+	r.servingCertCaBundleConfigMap = &corev1.ConfigMap{}
+	r.servingCertCaBundleConfigMap.Name = servingCertCABundleConfigMapName
+	r.servingCertCaBundleConfigMap.Namespace = r.namespace
 
 	r.onboardingValidationKeySecret = &corev1.Secret{}
 	r.onboardingValidationKeySecret.Name = onboardingValidationKeySecretName
@@ -501,6 +521,12 @@ func (r *ManagedOCSReconciler) reconcilePhases() (reconcile.Result, error) {
 			return ctrl.Result{}, err
 		}
 		if err := r.reconcileAlertRelabelConfigSecret(); err != nil {
+			return ctrl.Result{}, err
+		}
+		if err := r.reconcilePrometheusService(); err != nil {
+			return ctrl.Result{}, err
+		}
+		if err := r.reconcileServingCertCABundleConfigMap(); err != nil {
 			return ctrl.Result{}, err
 		}
 		if err := r.reconcilePrometheus(); err != nil {
@@ -885,6 +911,51 @@ func (r *ManagedOCSReconciler) reconcileAlertRelabelConfigSecret() error {
 	return nil
 }
 
+// reconcilePrometheusService function wait for prometheus Service
+// to start and sets appropriate annotation for 'service-ca' controller
+func (r *ManagedOCSReconciler) reconcilePrometheusService() error {
+	r.Log.Info("Reconciling prometheusService")
+
+	_, err := ctrl.CreateOrUpdate(r.ctx, r.Client, r.prometheusService, func() error {
+		if err := r.own(r.prometheusService); err != nil {
+			return err
+		}
+
+		r.prometheusService.Spec.Ports = []corev1.ServicePort{
+			{
+				Name:       "odf-prometheus-endpoint",
+				Protocol:   corev1.ProtocolTCP,
+				Port:       9339,
+				TargetPort: intstr.FromString("web"),
+			},
+		}
+		r.prometheusService.Spec.Selector = map[string]string{
+			monLabelKey: monLabelValue,
+		}
+		utils.AddAnnotation(r.prometheusService,
+			servingCertSecretBetaAnnotationKey, prometheusServiceSecretName)
+		utils.AddAnnotation(r.prometheusService,
+			servingCertSecretAlphaAnnotationKey, prometheusServiceSecretName)
+		return nil
+	})
+	return err
+}
+
+func (r *ManagedOCSReconciler) reconcileServingCertCABundleConfigMap() error {
+	r.Log.Info("Reconciling servingCertCABundleConfigMap")
+	_, err := ctrl.CreateOrUpdate(r.ctx, r.Client, r.servingCertCaBundleConfigMap, func() error {
+		if err := r.own(r.servingCertCaBundleConfigMap); err != nil {
+			return err
+		}
+		utils.AddAnnotation(r.servingCertCaBundleConfigMap,
+			servingCertConfigMapBetaAnnotationKey, "true")
+		utils.AddAnnotation(r.servingCertCaBundleConfigMap,
+			servingCertConfigMapAlphaAnnotationKey, "true")
+		return nil
+	})
+	return err
+}
+
 func (r *ManagedOCSReconciler) reconcilePrometheus() error {
 	r.Log.Info("Reconciling Prometheus")
 
@@ -903,6 +974,11 @@ func (r *ManagedOCSReconciler) reconcilePrometheus() error {
 			},
 			Key: alertRelabelConfigSecretKey,
 		}
+
+		tlsConfig := r.prometheus.Spec.Web.TLSConfig
+		tlsConfig.KeySecret.LocalObjectReference.Name = prometheusServiceSecretName
+		tlsConfig.Cert.Secret.LocalObjectReference.Name = prometheusServiceSecretName
+		tlsConfig.ClientCA.ConfigMap.LocalObjectReference.Name = servingCertCABundleConfigMapName
 
 		return nil
 	})

--- a/templates/prometheus.go
+++ b/templates/prometheus.go
@@ -17,8 +17,12 @@ limitations under the License.
 package templates
 
 import (
+	"crypto/tls"
+	"fmt"
+
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/red-hat-storage/ocs-osd-deployer/utils"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -45,5 +49,23 @@ var PrometheusTemplate = promv1.Prometheus{
 			}},
 		},
 		Resources: utils.GetResourceRequirements("prometheus"),
+		Web: &promv1.WebSpec{
+			TLSConfig: &promv1.WebTLSConfig{
+				KeySecret: corev1.SecretKeySelector{
+					Key: "tls.key",
+				},
+				Cert: promv1.SecretOrConfigMap{
+					Secret: &corev1.SecretKeySelector{
+						Key: "tls.crt",
+					},
+				},
+				ClientAuthType: fmt.Sprint(tls.VerifyClientCertIfGiven),
+				ClientCA: promv1.SecretOrConfigMap{
+					ConfigMap: &corev1.ConfigMapKeySelector{
+						Key: "service-ca.crt",
+					},
+				},
+			},
+		},
 	},
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,8 +17,9 @@ limitations under the License.
 package utils
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Contains checks whether a string is contained within a slice
@@ -50,6 +51,15 @@ func AddLabel(obj metav1.Object, key string, value string) {
 		obj.SetLabels(labels)
 	}
 	labels[key] = value
+}
+
+func AddAnnotation(obj metav1.Object, key string, value string) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+		obj.SetAnnotations(annotations)
+	}
+	annotations[key] = value
 }
 
 // GetRegexMatcher converts list of alerts to regex matcher


### PR DESCRIPTION
TLS support enables endpoints to be more secured.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>