### PR TITLE
Fix intermittent unittest failures

### DIFF
--- a/controllers/managedocs_controller_test.go
+++ b/controllers/managedocs_controller_test.go
@@ -489,6 +489,7 @@ var _ = Describe("ManagedOCS controller", func() {
 			} else {
 				Expect(k8sClient.Create(ctx, pdSecret)).Should(Succeed())
 			}
+			utils.WaitForResource(k8sClient, ctx, pdSecret, timeout*3, interval)
 		} else if pdSecretExists {
 			Expect(k8sClient.Delete(ctx, pdSecret)).Should(Succeed())
 		}


### PR DESCRIPTION
Grafana datasources secret discovery and AlertmanagerConfig creation
tests were failing because we don't wait for the PagerDuty secret don't
exists.

Change is to wait for the PagerDuty secret resource to be available.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>