### PR TITLE
Editing scorecard for ms release pipeline fix

### DIFF
--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -6,5 +6,6 @@
     - basic-check-spec
     image: quay.io/operator-framework/scorecard-test:v1.2.0
     labels:
+      phase: msp-main
       suite: basic
       test: basic-check-spec-test

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -6,6 +6,7 @@
     - olm-bundle-validation
     image: quay.io/operator-framework/scorecard-test:v1.2.0
     labels:
+      phase: msp-main
       suite: olm
       test: olm-bundle-validation-test
 - op: add
@@ -16,6 +17,7 @@
     - olm-crds-have-validation
     image: quay.io/operator-framework/scorecard-test:v1.2.0
     labels:
+      phase: msp-main
       suite: olm
       test: olm-crds-have-validation-test
 - op: add
@@ -26,6 +28,7 @@
     - olm-crds-have-resources
     image: quay.io/operator-framework/scorecard-test:v1.2.0
     labels:
+      phase: msp-main
       suite: olm
       test: olm-crds-have-resources-test
 - op: add
@@ -36,6 +39,7 @@
     - olm-spec-descriptors
     image: quay.io/operator-framework/scorecard-test:v1.2.0
     labels:
+      phase: msp-main
       suite: olm
       test: olm-spec-descriptors-test
 - op: add
@@ -46,5 +50,6 @@
     - olm-status-descriptors
     image: quay.io/operator-framework/scorecard-test:v1.2.0
     labels:
+      phase: msp-main
       suite: olm
       test: olm-status-descriptors-test


### PR DESCRIPTION
Our 'bundle/test/scorecard/config.yaml' expects another field under `label` that is `phase: msp-main`. This is a possible fix for our ms-release pipeline. 

Signed-off-by: akkhanna akkhanna@redhat.com