### PR TITLE
BZ: 2070898 Increase memory resource limits for provider storagecluster osds.

### DIFF
--- a/utils/resources.go
+++ b/utils/resources.go
@@ -57,11 +57,11 @@ var resourceRequirements = map[string]corev1.ResourceRequirements{
 	"sds": {
 		Limits: corev1.ResourceList{
 			"cpu":    resource.MustParse("2000m"),
-			"memory": resource.MustParse("5Gi"),
+			"memory": resource.MustParse("7Gi"),
 		},
 		Requests: corev1.ResourceList{
 			"cpu":    resource.MustParse("1000m"),
-			"memory": resource.MustParse("5Gi"),
+			"memory": resource.MustParse("7Gi"),
 		},
 	},
 	"prometheus": {


### PR DESCRIPTION
This path would increase  the memory limits of Provider storage cluster osd pods from `5Gi` to `7Gi` to improve performance.