### PR TITLE
BZ: 2070898 Added rook  override configs during Consumer storage cluster creation

### DIFF
--- a/templates/providerstoragecluster.go
+++ b/templates/providerstoragecluster.go
@@ -95,6 +95,9 @@ var ProviderStorageClusterTemplate = ocsv1.StorageCluster{
 			CephFilesystems: ocsv1.ManageCephFilesystems{
 				DisableStorageClass: false,
 			},
+			CephConfig: ocsv1.ManageCephConfig{
+				ReconcileStrategy: "ignore",
+			},
 		},
 	},
 }


### PR DESCRIPTION
Added the following options to be created in a ConfigMap before Storage cluster creation.
```
[global]
osd_pool_pg_autoscale_mode = off
osd_pool_default_pg_num = 128
osd_pool_default_pgp_num = 128
```
