### PR TITLE
Added new metrics to be federated according to new alertRules

### DIFF
--- a/templates/k8smetricsservicemonitor.go
+++ b/templates/k8smetricsservicemonitor.go
@@ -24,6 +24,8 @@ var params = map[string][]string{
 		"{__name__='kube_persistentvolume_info'}",
 		"{__name__='kube_storageclass_info'}",
 		"{__name__='kube_persistentvolumeclaim_info'}",
+		"{__name__='kube_deployment_spec_replicas'}",
+		"{__name__='kube_pod_status_phase'}",
 		"{__name__='kubelet_volume_stats_capacity_bytes'}",
 		"{__name__='kubelet_volume_stats_used_bytes'}",
 		"{__name__='node_disk_read_time_seconds_total'}",
@@ -45,14 +47,19 @@ var K8sMetricsServiceMonitorTemplate = promv1.ServiceMonitor{
 				ScrapeTimeout: "1m",
 				Interval:      "2m",
 				HonorLabels:   true,
-				MetricRelabelConfigs: []*promv1.RelabelConfig{
+				RelabelConfigs: []*promv1.RelabelConfig{
 					{
 						Action: "labeldrop",
 						Regex:  "prometheus_replica",
 					},
 					{
-						Action: "labeldrop",
-						Regex:  "pod",
+						Action:      "replace",
+						Regex:       "prometheus-k8s-.*",
+						Replacement: "",
+						SourceLabels: []string{
+							"pod",
+						},
+						TargetLabel: "pod",
 					},
 				},
 				TLSConfig: &promv1.TLSConfig{


### PR DESCRIPTION
This fixes two alerts
1. CephMonQuorumLost
2. CephMgrIsMissingReplicas

As there are two replicas of the Prometheus pod in the openshift-monitoring namespace and when we execute PersistentVolumeUsageNearFull and PersistentVolumeUsageCritical alertRule we get this error `Error executing query: found duplicate series for the match group {storageclass="ocs-storagecluster-cephfs"} on the right hand-side of the operation: [{__name__="kube_storageclass_info", container="kube-rbac-proxy-main", endpoint="https-main", job="kube-state-metrics", namespace="openshift-monitoring", prometheus="openshift-monitoring/k8s", provisioner="openshift-storage.cephfs.csi.ceph.com", reclaim_policy="Delete", service="kube-state-metrics", storageclass="ocs-storagecluster-cephfs", volume_binding_mode="Immediate"}, {__name__="kube_storageclass_info", container="kube-rbac-proxy-main", endpoint="https-main", job="kube-state-metrics", namespace="openshift-monitoring", pod="prometheus-k8s-1", prometheus="openshift-monitoring/k8s", provisioner="openshift-storage.cephfs.csi.ceph.com", reclaim_policy="Delete", service="kube-state-metrics", storageclass="ocs-storagecluster-cephfs", volume_binding_mode="Immediate"}];many-to-many matching not allowed: matching labels must be unique on one side` so we added labeldrop for pod label.

But now CephMonQuorumLost alert requires pod label so we are relabelling in such a way that the metrics that have pod label whose value is prometheus-k8s-0 or prometheus-k8s-1 will be replaced with blank value.
```
Metric before change:
    kube_pod_status_phase{container="kube-rbac-proxy-main", endpoint="https-main", job="kube-state-metrics", namespace="openshift-monitoring", phase="Succeeded", pod="prometheus-k8s-1", prometheus="openshift-monitoring/k8s", service="kube-state-metrics", uid="071feb6a-7d97-4ec3-93fd-938d27c5a097"}
Metrics after change:
    kube_pod_status_phase{container="kube-rbac-proxy-main", endpoint="https-main", job="kube-state-metrics", namespace="openshift-monitoring", phase="Succeeded", prometheus="openshift-monitoring/k8s", service="kube-state-metrics", uid="071feb6a-7d97-4ec3-93fd-938d27c5a097"}
```

Signed-off-by: bindrad <dbindra@redhat.com>