### PR TITLE
Added missing rbac role for storageconsumers

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -181,6 +181,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ocs.openshift.io
+  resources:
+  - storageconsumers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - odf.openshift.io
   resources:
   - storagesystems

--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -157,6 +157,7 @@ type ManagedOCSReconciler struct {
 // +kubebuilder:rbac:groups=ocs.openshift.io,namespace=system,resources=managedocs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ocs.openshift.io,namespace=system,resources=storageclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ocs.openshift.io,namespace=system,resources=ocsinitializations,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=ocs.openshift.io,namespace=system,resources=storageconsumers,verbs=get;list;watch
 // +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=system,resources={alertmanagers,prometheuses,alertmanagerconfigs},verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=system,resources=prometheusrules,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=system,resources=podmonitors,verbs=get;list;watch;update;patch


### PR DESCRIPTION
RBAC roles were missing for StorageConsumer api causing issue when fetching the resources.
Signed-off-by: Kaustav Majumder <kmajumde@redhat.com>