### PR TITLE
GitHub actions configuration to run golangci-lint

### DIFF
--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -12,10 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set GO_VERSION
-        run: echo "GO_VERSION=$(grep -m 1 -r 'go' go.mod | awk '{print $2}')" >> $GITHUB_ENV
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
+      - name: Set up Go environment
+        uses: red-hat-storage/ocs-osd-deployer@main
       - name: Build operator docker image
         run: make docker-build

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,22 @@
+---
+name: golangci-lint
+
+on:
+  pull_request:
+    branches: 
+    - '*'
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go environment
+        uses: red-hat-storage/ocs-osd-deployer@main
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.46.2
+          args: --timeout 3m --verbose

--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -701,10 +701,7 @@ func (r *ManagedOCSReconciler) updateComponentStatus() {
 func (r *ManagedOCSReconciler) verifyComponentsDoNotExist() bool {
 	subComponent := r.managedOCS.Status.Components
 
-	if subComponent.StorageCluster.State == v1.ComponentNotFound {
-		return true
-	}
-	return false
+	return subComponent.StorageCluster.State == v1.ComponentNotFound
 }
 
 func (r *ManagedOCSReconciler) reconcileStorageCluster() error {
@@ -1180,13 +1177,12 @@ func (r *ManagedOCSReconciler) reconcileAlertmanagerConfig() error {
 			}
 		}
 
-		smtpSecretData := map[string][]byte{}
 		if r.smtpSecret.UID == "" {
 			if err := r.get(r.smtpSecret); err != nil {
 				return fmt.Errorf("Unable to get SMTP secret: %v", err)
 			}
 		}
-		smtpSecretData = r.smtpSecret.Data
+		smtpSecretData := r.smtpSecret.Data
 		smtpHost := string(smtpSecretData["host"])
 		if smtpHost == "" {
 			return fmt.Errorf("smtp secret does not contain a host entry")
@@ -1250,9 +1246,8 @@ func (r *ManagedOCSReconciler) reconcileK8SMetricsServiceMonitorAuthSecret() err
 		if err := r.own(r.k8sMetricsServiceMonitorAuthSecret); err != nil {
 			return err
 		}
-		var auth map[string][]byte = nil
-		var err error = nil
-		if auth, err = r.readGrafanaV1Secret(); err != nil {
+		auth, err := r.readGrafanaV1Secret()
+		if err != nil {
 			if errors.IsNotFound(err) {
 				r.Log.Info("Unable to find v1 grafana-datasources secret")
 				auth, err = r.readGrafanaV2Secret()

--- a/readinessProbe/readiness/suite_test.go
+++ b/readinessProbe/readiness/suite_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -46,11 +45,6 @@ import (
 const (
 	ManagedOCSName = "test-managedocs"
 	TestNamespace  = "default"
-
-	// Define utility constants for object names and testing timeouts/durations and intervals.
-	timeout  = time.Second * 10
-	duration = time.Second * 10
-	interval = time.Millisecond * 250
 )
 
 var cfg *rest.Config
@@ -93,7 +87,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(k8sClient).ToNot(BeNil())
 
-		go RunServer(k8sClient, types.NamespacedName{Name: ManagedOCSName, Namespace: TestNamespace}, ctrl.Log.WithName("readiness"))
+		go RunServer(k8sClient, types.NamespacedName{Name: ManagedOCSName, Namespace: TestNamespace}, ctrl.Log.WithName("readiness")) //nolint
 
 		ctx := context.Background()
 


### PR DESCRIPTION
This PR will enable us to run golangci-lint whenever a PR is raised or updated. The changes to code are based on the output of golangci-lint. 
Error before making changes to the code
```
readinessProbe/readiness/suite_test.go:51:2: `timeout` is unused (deadcode)
        timeout  = time.Second * 10
        ^
readinessProbe/readiness/suite_test.go:52:2: `duration` is unused (deadcode)
        duration = time.Second * 10
        ^
readinessProbe/readiness/suite_test.go:53:2: `interval` is unused (deadcode)
        interval = time.Millisecond * 250
        ^
readinessProbe/readiness/suite_test.go:96:15: Error return value is not checked (errcheck)
                go RunServer(k8sClient, types.NamespacedName{Name: ManagedOCSName, Namespace: TestNamespace}, ctrl.Log.WithName("readiness"))
                            ^
controllers/managedocs_controller.go:704:2: S1008: should use 'return subComponent.StorageCluster.State == v1.ComponentNotFound' instead of 'if subComponent.StorageCluster.State == v1.ComponentNotFound { return true }; return false' (gosimple)
        if subComponent.StorageCluster.State == v1.ComponentNotFound {
        ^
controllers/managedocs_controller.go:1183:3: ineffectual assignment to smtpSecretData (ineffassign)
                smtpSecretData := map[string][]byte{}
                ^
controllers/managedocs_controller.go:1253:7: ineffectual assignment to auth (ineffassign)
                var auth map[string][]byte = nil
                    ^
controllers/managedocs_controller.go:1254:7: ineffectual assignment to err (ineffassign)
                var err error = nil

```