### PR TITLE
Added NetworkPolicyReconcileStrategy to ManagedOCS Spec and Status

### DIFF
--- a/api/v1alpha1/managedocs_types.go
+++ b/api/v1alpha1/managedocs_types.go
@@ -35,7 +35,8 @@ const (
 
 // ManagedOCSSpec defines the desired state of ManagedOCS
 type ManagedOCSSpec struct {
-	ReconcileStrategy ReconcileStrategy `json:"reconcileStrategy,omitempty"`
+	ReconcileStrategy              ReconcileStrategy `json:"reconcileStrategy,omitempty"`
+	NetworkPolicyReconcileStrategy ReconcileStrategy `json:"networkPolicyReconcileStrategy,omitempty"`
 }
 
 type ComponentState string
@@ -59,8 +60,9 @@ type ComponentStatusMap struct {
 
 // ManagedOCSStatus defines the observed state of ManagedOCS
 type ManagedOCSStatus struct {
-	ReconcileStrategy ReconcileStrategy  `json:"reconcileStrategy,omitempty"`
-	Components        ComponentStatusMap `json:"components"`
+	ReconcileStrategy              ReconcileStrategy  `json:"reconcileStrategy,omitempty"`
+	Components                     ComponentStatusMap `json:"components"`
+	NetworkPolicyReconcileStrategy ReconcileStrategy  `json:"networkPolicyReconcileStrategy,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/ocs.openshift.io_managedocs.yaml
+++ b/config/crd/bases/ocs.openshift.io_managedocs.yaml
@@ -38,6 +38,10 @@ spec:
           spec:
             description: ManagedOCSSpec defines the desired state of ManagedOCS
             properties:
+              networkPolicyReconcileStrategy:
+                description: ReconcileStrategy represent the action the deployer should
+                  take whenever a recncile event occures
+                type: string
               reconcileStrategy:
                 description: ReconcileStrategy represent the action the deployer should
                   take whenever a recncile event occures
@@ -74,6 +78,10 @@ spec:
                 - prometheus
                 - storageCluster
                 type: object
+              networkPolicyReconcileStrategy:
+                description: ReconcileStrategy represent the action the deployer should
+                  take whenever a recncile event occures
+                type: string
               reconcileStrategy:
                 description: ReconcileStrategy represent the action the deployer should
                   take whenever a recncile event occures


### PR DESCRIPTION
When NetworkPolicyReconcileStrategy is set to `none` the deployer will not reconcile any NetworkPolicies as well as set the status of NetworkPolicyReconcileStrategy in ManagedOCS CR as `none`
Sample CR
```
Kind: Managedocs
...
spec:
  networkPolicyReconcileStrategy: none
 ...
 status:
 networkPolicyReconcileStrategy: none
```
Jira: https://issues.redhat.com/browse/RHSTOR-3363

Signed-off-by: Kaustav Majumder <kmajumde@redhat.com>