### PR TITLE
Add metric_relabelling for prometheus_replicas label

### DIFF
--- a/templates/k8smetricsservicemonitor.go
+++ b/templates/k8smetricsservicemonitor.go
@@ -47,11 +47,13 @@ var K8sMetricsServiceMonitorTemplate = promv1.ServiceMonitor{
 				ScrapeTimeout: "1m",
 				Interval:      "2m",
 				HonorLabels:   true,
-				RelabelConfigs: []*promv1.RelabelConfig{
+				MetricRelabelConfigs: []*promv1.RelabelConfig{
 					{
 						Action: "labeldrop",
 						Regex:  "prometheus_replica",
 					},
+				},
+				RelabelConfigs: []*promv1.RelabelConfig{
 					{
 						Action:      "replace",
 						Regex:       "prometheus-k8s-.*",


### PR DESCRIPTION
The prometheus_replica label needs to be replaced after the metrics are scraped as this is added by the Prometheus in openshift-monitoring namespace so we need to use metric_relabelling. 
Whereas the pod label is added before the metrics are scraped so it needs to be relabelled using relabelling and not metric_relabelling.

Signed-off-by: Dhruv Bindra <dbindra@redhat.com>