### PR TITLE
use bearerTokenFile for federating metrics into addon ns

### DIFF
--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -68,47 +67,43 @@ const (
 )
 
 const (
-	managedOCSName                         = "managedocs"
-	storageClusterName                     = "ocs-storagecluster"
-	prometheusName                         = "managed-ocs-prometheus"
-	prometheusServiceName                  = "prometheus"
-	alertmanagerName                       = "managed-ocs-alertmanager"
-	alertmanagerConfigName                 = "managed-ocs-alertmanager-config"
-	dmsRuleName                            = "dms-monitor-rule"
-	storageSizeKey                         = "size"
-	storageUnitKey                         = "unit"
-	onboardingTicketKey                    = "onboarding-ticket"
-	storageProviderEndpointKey             = "storage-provider-endpoint"
-	enableMCGKey                           = "enable-mcg"
-	notificationEmailKeyPrefix             = "notification-email"
-	onboardingValidationKey                = "onboarding-validation-key"
-	deviceSetName                          = "default"
-	storageClassRbdName                    = "ocs-storagecluster-ceph-rbd"
-	storageClassCephFSName                 = "ocs-storagecluster-cephfs"
-	deployerCSVPrefix                      = "ocs-osd-deployer"
-	ocsOperatorName                        = "ocs-operator"
-	mcgOperatorName                        = "mcg-operator"
-	egressNetworkPolicyName                = "egress-rule"
-	ingressNetworkPolicyName               = "ingress-rule"
-	cephIngressNetworkPolicyName           = "ceph-ingress-rule"
-	providerApiServerNetworkPolicyName     = "provider-api-server-rule"
-	prometheusProxyNetworkPolicyName       = "prometheus-proxy-rule"
-	monLabelKey                            = "app"
-	monLabelValue                          = "managed-ocs"
-	rookConfigMapName                      = "rook-ceph-operator-config"
-	k8sMetricsServiceMonitorName           = "k8s-metrics-service-monitor"
-	grafanaDatasourceSecretName            = "grafana-datasources"
-	grafanaDatasourceSecretKey             = "prometheus.yaml"
-	k8sMetricsServiceMonitorAuthSecretName = "k8s-metrics-service-monitor-auth"
-	openshiftMonitoringNamespace           = "openshift-monitoring"
-	alertRelabelConfigSecretName           = "managed-ocs-alert-relabel-config-secret"
-	alertRelabelConfigSecretKey            = "alertrelabelconfig.yaml"
-	onboardingValidationKeySecretName      = "onboarding-ticket-key"
-	convergedDeploymentType                = "converged"
-	consumerDeploymentType                 = "consumer"
-	providerDeploymentType                 = "provider"
-	rhobsRemoteWriteConfigIdSecretKey      = "prom-remote-write-config-id"
-	rhobsRemoteWriteConfigSecretName       = "prom-remote-write-config-secret"
+	managedOCSName                     = "managedocs"
+	storageClusterName                 = "ocs-storagecluster"
+	prometheusName                     = "managed-ocs-prometheus"
+	prometheusServiceName              = "prometheus"
+	alertmanagerName                   = "managed-ocs-alertmanager"
+	alertmanagerConfigName             = "managed-ocs-alertmanager-config"
+	dmsRuleName                        = "dms-monitor-rule"
+	storageSizeKey                     = "size"
+	storageUnitKey                     = "unit"
+	onboardingTicketKey                = "onboarding-ticket"
+	storageProviderEndpointKey         = "storage-provider-endpoint"
+	enableMCGKey                       = "enable-mcg"
+	notificationEmailKeyPrefix         = "notification-email"
+	onboardingValidationKey            = "onboarding-validation-key"
+	deviceSetName                      = "default"
+	storageClassRbdName                = "ocs-storagecluster-ceph-rbd"
+	storageClassCephFSName             = "ocs-storagecluster-cephfs"
+	deployerCSVPrefix                  = "ocs-osd-deployer"
+	ocsOperatorName                    = "ocs-operator"
+	mcgOperatorName                    = "mcg-operator"
+	egressNetworkPolicyName            = "egress-rule"
+	ingressNetworkPolicyName           = "ingress-rule"
+	cephIngressNetworkPolicyName       = "ceph-ingress-rule"
+	providerApiServerNetworkPolicyName = "provider-api-server-rule"
+	prometheusProxyNetworkPolicyName   = "prometheus-proxy-rule"
+	monLabelKey                        = "app"
+	monLabelValue                      = "managed-ocs"
+	rookConfigMapName                  = "rook-ceph-operator-config"
+	k8sMetricsServiceMonitorName       = "k8s-metrics-service-monitor"
+	alertRelabelConfigSecretName       = "managed-ocs-alert-relabel-config-secret"
+	alertRelabelConfigSecretKey        = "alertrelabelconfig.yaml"
+	onboardingValidationKeySecretName  = "onboarding-ticket-key"
+	convergedDeploymentType            = "converged"
+	consumerDeploymentType             = "consumer"
+	providerDeploymentType             = "provider"
+	rhobsRemoteWriteConfigIdSecretKey  = "prom-remote-write-config-id"
+	rhobsRemoteWriteConfigSecretName   = "prom-remote-write-config-secret"
 )
 
 // ManagedOCSReconciler reconciles a ManagedOCS object
@@ -132,31 +127,30 @@ type ManagedOCSReconciler struct {
 	RHOBSEndpoint                string
 	RHSSOTokenEndpoint           string
 
-	ctx                                context.Context
-	managedOCS                         *v1.ManagedOCS
-	storageCluster                     *ocsv1.StorageCluster
-	egressNetworkPolicy                *openshiftv1.EgressNetworkPolicy
-	ingressNetworkPolicy               *netv1.NetworkPolicy
-	cephIngressNetworkPolicy           *netv1.NetworkPolicy
-	providerAPIServerNetworkPolicy     *netv1.NetworkPolicy
-	prometheusProxyNetworkPolicy       *netv1.NetworkPolicy
-	prometheus                         *promv1.Prometheus
-	prometheusService                  *corev1.Service
-	dmsRule                            *promv1.PrometheusRule
-	alertmanager                       *promv1.Alertmanager
-	pagerdutySecret                    *corev1.Secret
-	deadMansSnitchSecret               *corev1.Secret
-	smtpSecret                         *corev1.Secret
-	alertmanagerConfig                 *promv1a1.AlertmanagerConfig
-	alertRelabelConfigSecret           *corev1.Secret
-	k8sMetricsServiceMonitor           *promv1.ServiceMonitor
-	k8sMetricsServiceMonitorAuthSecret *corev1.Secret
-	namespace                          string
-	reconcileStrategy                  v1.ReconcileStrategy
-	addonParams                        map[string]string
-	onboardingValidationKeySecret      *corev1.Secret
-	prometheusKubeRBACConfigMap        *corev1.ConfigMap
-	rhobsRemoteWriteConfigSecret       *corev1.Secret
+	ctx                            context.Context
+	managedOCS                     *v1.ManagedOCS
+	storageCluster                 *ocsv1.StorageCluster
+	egressNetworkPolicy            *openshiftv1.EgressNetworkPolicy
+	ingressNetworkPolicy           *netv1.NetworkPolicy
+	cephIngressNetworkPolicy       *netv1.NetworkPolicy
+	providerAPIServerNetworkPolicy *netv1.NetworkPolicy
+	prometheusProxyNetworkPolicy   *netv1.NetworkPolicy
+	prometheus                     *promv1.Prometheus
+	prometheusService              *corev1.Service
+	dmsRule                        *promv1.PrometheusRule
+	alertmanager                   *promv1.Alertmanager
+	pagerdutySecret                *corev1.Secret
+	deadMansSnitchSecret           *corev1.Secret
+	smtpSecret                     *corev1.Secret
+	alertmanagerConfig             *promv1a1.AlertmanagerConfig
+	alertRelabelConfigSecret       *corev1.Secret
+	k8sMetricsServiceMonitor       *promv1.ServiceMonitor
+	namespace                      string
+	reconcileStrategy              v1.ReconcileStrategy
+	addonParams                    map[string]string
+	onboardingValidationKeySecret  *corev1.Secret
+	prometheusKubeRBACConfigMap    *corev1.ConfigMap
+	rhobsRemoteWriteConfigSecret   *corev1.Secret
 }
 
 // Add necessary rbac permissions for managedocs finalizer in order to set blockOwnerDeletion.
@@ -432,10 +426,6 @@ func (r *ManagedOCSReconciler) initReconciler(ctx context.Context, req ctrl.Requ
 	r.k8sMetricsServiceMonitor.Name = k8sMetricsServiceMonitorName
 	r.k8sMetricsServiceMonitor.Namespace = r.namespace
 
-	r.k8sMetricsServiceMonitorAuthSecret = &corev1.Secret{}
-	r.k8sMetricsServiceMonitorAuthSecret.Name = k8sMetricsServiceMonitorAuthSecretName
-	r.k8sMetricsServiceMonitorAuthSecret.Namespace = r.namespace
-
 	r.alertRelabelConfigSecret = &corev1.Secret{}
 	r.alertRelabelConfigSecret.Name = alertRelabelConfigSecretName
 	r.alertRelabelConfigSecret.Namespace = r.namespace
@@ -563,9 +553,6 @@ func (r *ManagedOCSReconciler) reconcilePhases() (reconcile.Result, error) {
 			return ctrl.Result{}, err
 		}
 		if err := r.reconcileAlertmanagerConfig(); err != nil {
-			return ctrl.Result{}, err
-		}
-		if err := r.reconcileK8SMetricsServiceMonitorAuthSecret(); err != nil {
 			return ctrl.Result{}, err
 		}
 		if err := r.reconcileK8SMetricsServiceMonitor(); err != nil {
@@ -1296,100 +1283,6 @@ func (r *ManagedOCSReconciler) reconcileAlertmanagerConfig() error {
 	return err
 }
 
-func (r *ManagedOCSReconciler) reconcileK8SMetricsServiceMonitorAuthSecret() error {
-	r.Log.Info("Reconciling k8sMetricsServiceMonitorAuthSecret")
-
-	_, err := ctrl.CreateOrUpdate(r.ctx, r.Client, r.k8sMetricsServiceMonitorAuthSecret, func() error {
-		if err := r.own(r.k8sMetricsServiceMonitorAuthSecret); err != nil {
-			return err
-		}
-		auth, err := r.readGrafanaV1Secret()
-		if err != nil {
-			if errors.IsNotFound(err) {
-				r.Log.Info("Unable to find v1 grafana-datasources secret")
-				auth, err = r.readGrafanaV2Secret()
-			}
-			if err != nil {
-				return fmt.Errorf("Unable to find grafana-datasources secret: %v", err)
-			}
-		}
-		r.k8sMetricsServiceMonitorAuthSecret.Data = auth
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("Failed to update k8sMetricsServiceMonitorAuthSecret: %v", err)
-	}
-	return nil
-}
-
-func (r *ManagedOCSReconciler) readGrafanaV1Secret() (map[string][]byte, error) {
-	secret := &corev1.Secret{}
-	secret.Name = grafanaDatasourceSecretName
-	secret.Namespace = openshiftMonitoringNamespace
-	if err := r.unrestrictedGet(secret); err != nil {
-		return nil, err
-	}
-	authInfoStructure := struct {
-		DataSources []struct {
-			BasicAuthPassword string `json:"basicAuthPassword"`
-			BasicAuthUser     string `json:"basicAuthUser"`
-		} `json:"datasources"`
-	}{}
-	if err := json.Unmarshal(secret.Data[grafanaDatasourceSecretKey], &authInfoStructure); err != nil {
-		return nil, err
-	}
-	var authDetails map[string][]byte = nil
-	for key := range authInfoStructure.DataSources {
-		ds := &authInfoStructure.DataSources[key]
-		if ds.BasicAuthUser == "internal" && ds.BasicAuthPassword != "" {
-			authDetails = map[string][]byte{
-				"Username": []byte(ds.BasicAuthUser),
-				"Password": []byte(ds.BasicAuthPassword),
-			}
-			break
-		}
-	}
-	if authDetails == nil {
-		return nil, fmt.Errorf("grafana-datasources does not contain required credentials")
-	}
-	return authDetails, nil
-}
-
-func (r *ManagedOCSReconciler) readGrafanaV2Secret() (map[string][]byte, error) {
-	secret := &corev1.Secret{}
-	secret.Name = "grafana-datasources-v2"
-	secret.Namespace = openshiftMonitoringNamespace
-	if err := r.unrestrictedGet(secret); err != nil {
-		return nil, err
-	}
-	authInfoStructure := struct {
-		DataSources []struct {
-			SecureJsonData struct {
-				BasicAuthPassword string `json:"basicAuthPassword"`
-			} `json:"secureJsonData"`
-			BasicAuthUser string `json:"basicAuthUser"`
-		} `json:"datasources"`
-	}{}
-	if err := json.Unmarshal(secret.Data[grafanaDatasourceSecretKey], &authInfoStructure); err != nil {
-		return nil, err
-	}
-	var authDetails map[string][]byte = nil
-	for key := range authInfoStructure.DataSources {
-		ds := &authInfoStructure.DataSources[key]
-		if ds.BasicAuthUser == "internal" && ds.SecureJsonData.BasicAuthPassword != "" {
-			authDetails = map[string][]byte{
-				"Username": []byte(ds.BasicAuthUser),
-				"Password": []byte(ds.SecureJsonData.BasicAuthPassword),
-			}
-			break
-		}
-	}
-	if authDetails == nil {
-		return nil, fmt.Errorf("grafana-datasources-v2 does not contain required credentials")
-	}
-	return authDetails, nil
-}
-
 func (r *ManagedOCSReconciler) reconcileK8SMetricsServiceMonitor() error {
 	r.Log.Info("Reconciling k8sMetricsServiceMonitor")
 
@@ -1899,11 +1792,6 @@ func (r *ManagedOCSReconciler) getCSVByPrefix(name string) (*opv1a1.ClusterServi
 		}
 	}
 	return nil, errors.NewNotFound(opv1a1.Resource("csv"), fmt.Sprintf("unable to find a csv prefixed with %s", name))
-}
-
-func (r *ManagedOCSReconciler) unrestrictedGet(obj client.Object) error {
-	key := client.ObjectKeyFromObject(obj)
-	return r.UnrestrictedClient.Get(r.ctx, key, obj)
 }
 
 func findStorageDeviceSet(storageDeviceSets []ocsv1.StorageDeviceSet, deviceSetName string) *ocsv1.StorageDeviceSet {

--- a/controllers/managedocs_controller_test.go
+++ b/controllers/managedocs_controller_test.go
@@ -288,33 +288,9 @@ var _ = Describe("ManagedOCS controller", func() {
 			Namespace: testPrimaryNamespace,
 		},
 	}
-	var grafanaDatasources struct {
-		Datasources [1]struct {
-			BasicAuthPassword string `json:"basicAuthPassword"`
-			BasicAuthUser     string `json:"basicAuthUser"`
-		} `json:"datasources"`
-	}
-	grafanaDatasources.Datasources[0].BasicAuthPassword = "password"
-	grafanaDatasources.Datasources[0].BasicAuthUser = "internal"
-	grafanaDatasourceSecretTemplate := corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testGrafanaFederateSecretName,
-			Namespace: testOpenshiftMonitoringNamespace,
-		},
-		Data: map[string][]byte{
-			"prometheus.yaml": utils.ToJsonOrDie(grafanaDatasources),
-		},
-	}
-	k8sMetricsServiceMonitorAuthSecretTemplate := corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testK8sMetricsServiceMonitorAuthSecretName,
-			Namespace: testPrimaryNamespace,
-		},
-		StringData: map[string]string{},
-	}
 	k8sMetricsServiceMonitorTemplate := promv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "k8s-metrics-service-monitor",
+			Name:      k8sMetricsServiceMonitorName,
 			Namespace: testPrimaryNamespace,
 		},
 	}
@@ -1360,16 +1336,11 @@ var _ = Describe("ManagedOCS controller", func() {
 				utils.WaitForResource(k8sClient, ctx, amConfigTemplate.DeepCopy(), timeout, interval)
 			})
 		})
-		When("a Grafana datasources secret exists in the openshift-monitoring namespace", func() {
-			It("should create k8sMetricsServiceMonitorAuthSecret in primary namespace", func() {
-				grafanaSecret := grafanaDatasourceSecretTemplate.DeepCopy()
-				Expect(k8sClient.Create(ctx, grafanaSecret)).Should(Succeed())
-				// Check for federate-basic-auth secret in primary namespace
-				utils.WaitForResource(k8sClient, ctx, k8sMetricsServiceMonitorAuthSecretTemplate.DeepCopy(), timeout, interval)
-			})
-		})
 		When("k8sMetricsServiceMonitor is modified", func() {
 			It("should revert the changes and bring the resource back to its managed state", func() {
+				// Wait for the resource to be created
+				utils.WaitForResource(k8sClient, ctx, k8sMetricsServiceMonitorTemplate.DeepCopy(), timeout, interval)
+
 				sm := k8sMetricsServiceMonitorTemplate.DeepCopy()
 				smKey := utils.GetResourceKey(sm)
 				Expect(k8sClient.Get(ctx, smKey, sm)).Should(Succeed())

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -65,23 +65,20 @@ var (
 )
 
 const (
-	testPrimaryNamespace                       = "primary"
-	testSecondaryNamespace                     = "secondary"
-	testAddonParamsSecretName                  = "test-addon-secret"
-	testPagerdutySecretName                    = "test-pagerduty-secret"
-	testDeadMansSnitchSecretName               = "test-deadmanssnitch-secret"
-	testSMTPSecretName                         = "test-smtp-secret"
-	testAddonConfigMapName                     = "test-addon-configmap"
-	testAddonConfigMapDeleteLabelKey           = "test-addon-configmap-delete-label-key"
-	testDeployerCSVName                        = "ocs-osd-deployer.x.y.z"
-	testGrafanaFederateSecretName              = "grafana-datasources"
-	testK8sMetricsServiceMonitorAuthSecretName = "k8s-metrics-service-monitor-auth"
-	testOpenshiftMonitoringNamespace           = "openshift-monitoring"
-	testCustomerNotificationHTMLPath           = "../templates/customernotification.html"
-	testDeploymentTypeEnvVarName               = "DEPLOYMENT_TYPE"
-	testRHOBSEndpointEnvVarName                = "RHOBS_ENDPOINT"
-	testRHssoTokenEndpointEnvVarName           = "RH_SSO_TOKEN_ENDPOINT"
-	testRHOBSSecretName                        = "test-addon-prom-remote-write"
+	testPrimaryNamespace             = "primary"
+	testSecondaryNamespace           = "secondary"
+	testAddonParamsSecretName        = "test-addon-secret"
+	testPagerdutySecretName          = "test-pagerduty-secret"
+	testDeadMansSnitchSecretName     = "test-deadmanssnitch-secret"
+	testSMTPSecretName               = "test-smtp-secret"
+	testAddonConfigMapName           = "test-addon-configmap"
+	testAddonConfigMapDeleteLabelKey = "test-addon-configmap-delete-label-key"
+	testDeployerCSVName              = "ocs-osd-deployer.x.y.z"
+	testCustomerNotificationHTMLPath = "../templates/customernotification.html"
+	testDeploymentTypeEnvVarName     = "DEPLOYMENT_TYPE"
+	testRHOBSEndpointEnvVarName      = "RHOBS_ENDPOINT"
+	testRHssoTokenEndpointEnvVarName = "RH_SSO_TOKEN_ENDPOINT"
+	testRHOBSSecretName              = "test-addon-prom-remote-write"
 )
 
 func TestAPIs(t *testing.T) {
@@ -215,10 +212,6 @@ var _ = BeforeSuite(func() {
 		secondaryNS := &corev1.Namespace{}
 		secondaryNS.Name = testSecondaryNamespace
 		Expect(k8sClient.Create(ctx, secondaryNS)).Should(Succeed())
-
-		openshiftMonitoringNS := &corev1.Namespace{}
-		openshiftMonitoringNS.Name = testOpenshiftMonitoringNamespace
-		Expect(k8sClient.Create(ctx, openshiftMonitoringNS)).Should(Succeed())
 
 		// Create a mock MCG CSV
 		mcgCSV := &opv1a1.ClusterServiceVersion{}

--- a/makefileutils.yaml
+++ b/makefileutils.yaml
@@ -73,16 +73,3 @@ spec:
                     image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
     strategy: deployment
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-monitoring
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: grafana-datasources-v2
-  namespace: openshift-monitoring
-type: Opaque
-data:
-  prometheus.yaml: ewogICAgImRhdGFzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICAgInNlY3VyZUpzb25EYXRhIjogewogICAgICAgICAgICAgICAgImJhc2ljQXV0aFBhc3N3b3JkIjogInRlc3QiCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJiYXNpY0F1dGhVc2VyIjogImludGVybmFsIgogICAgICAgIH0KICAgIF0KfQ==

--- a/templates/k8smetricsservicemonitor.go
+++ b/templates/k8smetricsservicemonitor.go
@@ -14,7 +14,6 @@ package templates
 
 import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -34,8 +33,6 @@ var params = map[string][]string{
 		"{__name__='node_disk_writes_completed_total'}",
 	},
 }
-
-var k8sMetricsServiceMonitorAuthSecret = "k8s-metrics-service-monitor-auth"
 
 var K8sMetricsServiceMonitorTemplate = promv1.ServiceMonitor{
 	Spec: promv1.ServiceMonitorSpec{
@@ -69,21 +66,8 @@ var K8sMetricsServiceMonitorTemplate = promv1.ServiceMonitor{
 						InsecureSkipVerify: true,
 					},
 				},
-				Params: params,
-				BasicAuth: &promv1.BasicAuth{
-					Username: corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: k8sMetricsServiceMonitorAuthSecret,
-						},
-						Key: "Username",
-					},
-					Password: corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: k8sMetricsServiceMonitorAuthSecret,
-						},
-						Key: "Password",
-					},
-				},
+				Params:          params,
+				BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 			},
 		},
 		NamespaceSelector: promv1.NamespaceSelector{


### PR DESCRIPTION
- remove usage of grafana secret
- remove reconcile phase for creating authentication secret based on
  grafana secret
- remove corresponding unit test mocks and tests
- remove unused `unrestrictedGet` method on reconciler

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>