### PR TITLE
Configure deployer to only remote write metrics from provider clusters

### DIFF
--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -1061,7 +1061,7 @@ func (r *ManagedOCSReconciler) reconcilePrometheus() error {
 			},
 			Key: alertRelabelConfigSecretKey,
 		}
-		if r.DeploymentType != convergedDeploymentType {
+		if r.DeploymentType == providerDeploymentType {
 			if err := r.get(r.rhobsRemoteWriteConfigSecret); err != nil && !errors.IsNotFound(err) {
 				return err
 			}
@@ -1090,7 +1090,7 @@ func (r *ManagedOCSReconciler) reconcilePrometheus() error {
 				r.prometheus.Spec.RemoteWrite = nil
 			}
 		} else {
-			// removing remote write spec for converged clusters
+			// removing remote write spec for converged/consumer clusters
 			r.prometheus.Spec.RemoteWrite = nil
 		}
 		return nil

--- a/controllers/managedocs_controller_test.go
+++ b/controllers/managedocs_controller_test.go
@@ -645,7 +645,7 @@ var _ = Describe("ManagedOCS controller", func() {
 		})
 		When("there is no rhobs secret", func() {
 			It("should  create prometheus resource without remote write spec", func() {
-				if testReconciler.DeploymentType != convergedDeploymentType {
+				if testReconciler.DeploymentType == providerDeploymentType {
 					utils.WaitForResource(k8sClient, ctx, promTemplate.DeepCopy(), timeout, interval)
 					Eventually(func() bool {
 						prom := promTemplate.DeepCopy()
@@ -660,7 +660,7 @@ var _ = Describe("ManagedOCS controller", func() {
 		})
 		When("there is a rhobs secret with missing values", func() {
 			It("should not create prometheus resource with remote write spec", func() {
-				if testReconciler.DeploymentType != convergedDeploymentType {
+				if testReconciler.DeploymentType == providerDeploymentType {
 					secret := rhobsSecretTemplate.DeepCopy()
 					delete(secret.Data, "prom-remote-write-config-id")
 					Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
@@ -677,7 +677,7 @@ var _ = Describe("ManagedOCS controller", func() {
 		})
 		When("there is a rhobs secret", func() {
 			It("should create prometheus resources", func() {
-				if testReconciler.DeploymentType != convergedDeploymentType {
+				if testReconciler.DeploymentType == providerDeploymentType {
 					secret := rhobsSecretTemplate.DeepCopy()
 					Expect(k8sClient.Update(ctx, secret)).Should(Succeed())
 					utils.WaitForResource(k8sClient, ctx, promTemplate.DeepCopy(), timeout, interval)

--- a/templates/prometheus.go
+++ b/templates/prometheus.go
@@ -59,13 +59,10 @@ var metrics = []string{
 	"job:ceph_versions_running:count",
 	"job:ceph_pools_iops_bytes:total",
 	"job:ceph_pools_iops:total",
-	"job:kube_pv:count",
 	"job:ceph_osd_metadata:count",
 	"ceph_health_status",
 	"ceph_cluster_total_used_raw_bytes",
 	"ceph_cluster_total_bytes",
-	"cluster:kubelet_volume_stats_used_bytes:provisioner:sum",
-	"cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum",
 }
 
 var PrometheusTemplate = promv1.Prometheus{


### PR DESCRIPTION
- Removed metrics related to consumer clusters

Signed-off-by: Kaustav Majumder <kmajumde@redhat.com>