### PR TITLE
Add missing metrics from in-cluster monitoring

### DIFF
--- a/controllers/managedocs_controller_test.go
+++ b/controllers/managedocs_controller_test.go
@@ -322,14 +322,14 @@ var _ = Describe("ManagedOCS controller", func() {
 			Enable:   true,
 		},
 	}
-	remoteWriteRegexString := "(ALERTS;(CephMdsMissingReplicas|CephMgrIsAbsent|CephMgrIsMissingReplicas|CephNodeDown|" +
+	providerRemoteWriteRegexString := "(ALERTS;(CephMdsMissingReplicas|CephMgrIsAbsent|CephMgrIsMissingReplicas|CephNodeDown|" +
 		"CephClusterErrorState|CephClusterWarningState|CephOSDVersionMismatch|CephMonVersionMismatch|CephOSDFlapping|" +
-		"CephOSDDiskNotResponding|CephOSDDiskUnavailable|CephDataRecoveryTakingTooLong|CephPGRepairTakingTooLong|" +
-		"CephMonQuorumAtRisk|CephMonQuorumLost))|(job:ceph_versions_running:count;)|" +
-		"(job:ceph_pools_iops_bytes:total;)|(job:ceph_pools_iops:total;)|(job:kube_pv:count;)" +
-		"|(job:ceph_osd_metadata:count;)|(ceph_health_status;)|(ceph_cluster_total_used_raw_bytes;)|" +
-		"(ceph_cluster_total_bytes;)|(cluster:kubelet_volume_stats_used_bytes:provisioner:sum;)|" +
-		"(cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum;)"
+		"CephOSDDiskNotResponding|CephOSDDiskUnavailable|CephDataRecoveryTakingTooLong|CephPGRepairTakingTooLong|CephMonQuorumAtRisk|" +
+		"CephMonQuorumLost))|(job:ceph_versions_running:count;)|(job:ceph_pools_iops_bytes:total;)|(job:ceph_pools_iops:total;)|" +
+		"(job:ceph_osd_metadata:count;)|(ceph_health_status;)|(ceph_cluster_total_used_raw_bytes;)|(ceph_cluster_total_bytes;)|(subscription_sync_total;)"
+
+	consumerRemoteWriteRegexString := "job:kube_pv:count|cluster:kubelet_volume_stats_used_bytes:provisioner:sum|" +
+		"cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum|subscription_sync_total"
 
 	setupUninstallConditions := func(
 		shouldAddonConfigMapExist bool,
@@ -701,11 +701,19 @@ var _ = Describe("ManagedOCS controller", func() {
 			})
 			It("should have approriate remote-write relabel configs", func() {
 				if testReconciler.DeploymentType != convergedDeploymentType {
-					prom := promTemplate.DeepCopy()
-					utils.WaitForResource(k8sClient, ctx, prom, timeout, interval)
-					Expect(prom.Spec.RemoteWrite[0].WriteRelabelConfigs[0].SourceLabels).Should(Equal([]string{"__name__", "alertname"}))
-					Expect(prom.Spec.RemoteWrite[0].WriteRelabelConfigs[0].Regex).Should(Equal(remoteWriteRegexString))
-					Expect(prom.Spec.RemoteWrite[0].WriteRelabelConfigs[0].Action).Should(Equal("keep"))
+					if testReconciler.DeploymentType == providerDeploymentType {
+						prom := promTemplate.DeepCopy()
+						utils.WaitForResource(k8sClient, ctx, prom, timeout, interval)
+						Expect(prom.Spec.RemoteWrite[0].WriteRelabelConfigs[0].SourceLabels).Should(Equal([]string{"__name__", "alertname"}))
+						Expect(prom.Spec.RemoteWrite[0].WriteRelabelConfigs[0].Regex).Should(Equal(providerRemoteWriteRegexString))
+						Expect(prom.Spec.RemoteWrite[0].WriteRelabelConfigs[0].Action).Should(Equal("keep"))
+					} else {
+						prom := promTemplate.DeepCopy()
+						utils.WaitForResource(k8sClient, ctx, prom, timeout, interval)
+						Expect(prom.Spec.RemoteWrite[0].WriteRelabelConfigs[0].SourceLabels).Should(Equal([]string{"__name__"}))
+						Expect(prom.Spec.RemoteWrite[0].WriteRelabelConfigs[0].Regex).Should(Equal(consumerRemoteWriteRegexString))
+						Expect(prom.Spec.RemoteWrite[0].WriteRelabelConfigs[0].Action).Should(Equal("keep"))
+					}
 				}
 			})
 		})

--- a/templates/k8smetricsservicemonitor.go
+++ b/templates/k8smetricsservicemonitor.go
@@ -31,6 +31,9 @@ var params = map[string][]string{
 		"{__name__='node_disk_write_time_seconds_total'}",
 		"{__name__='node_disk_reads_completed_total'}",
 		"{__name__='node_disk_writes_completed_total'}",
+		"{__name__='subscription_sync_total'}",
+		"{__name__='cluster:kubelet_volume_stats_used_bytes:provisioner:sum'}",
+		"{__name__='cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum'}",
 	},
 }
 


### PR DESCRIPTION
New metrics fetched from in-cluster monitoring:
- cluster:kubelet_volume_stats_used_bytes:provisioner:sum
- cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum
- subscription_sync_total

New Metric to be forwarded to RHOBS MST
- subscription_sync_total

Added `addonName` external label

Also [Segregating provider and consumer specific metrics to be pushed to RHOBS]


Signed-off-by: Kaustav Majumder <kmajumde@redhat.com>