### PR TITLE
Using AWS data for network policy setup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY controllers/ controllers/
 COPY utils/ utils/
 COPY templates/ templates/
 COPY readinessProbe/ readinessProbe/
+COPY cmd/awsDataGather/ awsDataGather/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
@@ -23,12 +24,18 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 # Build readiness probe binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o readinessServer readinessProbe/main.go
 
+# Build aws data gathering binary
+# Because the executable is the same name as the directory the source code is in,
+# Go will build it as awsDataGather/main; the name will be changed during the copy operation.
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o awsDataGather awsDataGather/main.go
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/readinessServer .
+COPY --from=builder /workspace/awsDataGather/main awsDataGather
 COPY --from=builder /workspace/templates/customernotification.html /templates/
 USER nonroot:nonroot
 

--- a/cmd/awsDataGather/main.go
+++ b/cmd/awsDataGather/main.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/red-hat-storage/ocs-osd-deployer/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const maxSleep time.Duration = 300
+
+func main() {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	log := ctrl.Log.WithName("main")
+
+	mainContext := context.Background()
+
+	namespace, found := os.LookupEnv("NAMESPACE")
+	if !found {
+		fmt.Fprintf(
+			os.Stderr,
+			"NAMESPACE environment variable not found\n",
+		)
+		os.Exit(1)
+	}
+	podName, found := os.LookupEnv("POD_NAME")
+	if !found {
+		fmt.Fprintf(
+			os.Stderr,
+			"POD_NAME environment variable not found\n",
+		)
+		os.Exit(1)
+	}
+
+	// We need the deployment name to use as an owner reference.
+	// However, the deployment name cannot be passed as an environment variable,
+	// so we derive it from the pod name.
+	deploymentName, err := utils.DeploymentNameFromPodName(podName)
+	if err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"Could not determine deployment name from pod name (%s)",
+			podName)
+		os.Exit(1)
+	}
+
+	log.Info("Setting up k8s client")
+	var options client.Options
+	options.Scheme = runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(options.Scheme))
+
+	k8sClient, err := client.New(config.GetConfigOrDie(), options)
+	if err != nil {
+		log.Error(err, "error creating client")
+		os.Exit(1)
+	}
+
+	// This will later be used as the OwnerReference for the data ConfigMap
+	var deployment appsv1.Deployment
+	err = k8sClient.Get(mainContext, client.ObjectKey{
+		Name:      deploymentName,
+		Namespace: namespace,
+	}, &deployment)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Failed to find deployment '%s' in namespace '%s'", deploymentName, namespace))
+		os.Exit(1)
+	}
+
+	var backoff time.Duration = 1
+	for {
+		var sleep time.Duration
+		log.Info("Gathering AWS data")
+		if err := gatherAndSaveData(utils.IMDSv1Server, deployment, k8sClient, mainContext); err == nil {
+			log.Info("AWS data gathering successfully completed!")
+			sleep = maxSleep
+			// Reset the backoff counter since data gathering succeeded.
+			backoff = 1
+		} else {
+			log.Error(err, "Failed to gather AWS data")
+			sleep = backoff
+			backoff = 2 * backoff
+			if backoff > maxSleep {
+				backoff = maxSleep
+			}
+		}
+		log.Info("Sleeping for %d seconds before next the fetch...", sleep)
+		time.Sleep(sleep * time.Second)
+	}
+}
+
+func gatherAndSaveData(imdsServer string, deployment appsv1.Deployment, k8sClient client.Client, context context.Context) error {
+	log := ctrl.Log.WithName("GatherData")
+
+	log.Info("Fetching AWS VPC IPv4 CIDR data")
+	cidr, err := utils.IMDSFetchIPv4CIDR(imdsServer)
+	if err != nil {
+		return fmt.Errorf("Failed to get VPC IPv4 CIDR: %v", err)
+	}
+
+	log.Info("Creating Config Map with AWS data")
+
+	configMap := corev1.ConfigMap{}
+	configMap.Name = utils.IMDSConfigMapName
+	configMap.Namespace = deployment.Namespace
+
+	_, err = ctrl.CreateOrUpdate(context, k8sClient, &configMap, func() error {
+		// Setting the owner of the configmap resource to this deployment that creates it.
+		// That way, the configmap will go away when the deployment does.
+		// The version and kind are being manually inserted because the deployment struct doesn't have it.
+		// See: https://github.com/kubernetes/client-go/issues/861#issuecomment-686806279
+		configMap.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       deployment.Name,
+				UID:        deployment.UID,
+			},
+		}
+
+		configMap.Data = map[string]string{
+			utils.CIDRKey: cidr,
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to create configmap: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/awsDataGather/main_test.go
+++ b/cmd/awsDataGather/main_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	tutils "github.com/red-hat-storage/ocs-osd-deployer/testutils"
+	"github.com/red-hat-storage/ocs-osd-deployer/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var _ = Describe("AWS Data Gathering behavior", func() {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctx := context.Background()
+
+	configMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.IMDSConfigMapName,
+			Namespace: testNamespace,
+		},
+	}
+
+	fakeDeployment := appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-deployment",
+			Namespace: testNamespace,
+			UID:       "foobar",
+		},
+	}
+
+	When("aws data gathering successfully completes", func() {
+		var awsConfigMap corev1.ConfigMap
+
+		BeforeEach(func() {
+			err := gatherAndSaveData("http://"+testMockerAddr, fakeDeployment, k8sClient, context.TODO())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should have created a configmap that is valid...", func() {
+			err := k8sClient.Get(ctx, tutils.GetResourceKey(&configMap), &awsConfigMap)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("having the VPC cidr key")
+			vpcCIDR, ok := awsConfigMap.Data[utils.CIDRKey]
+			Expect(ok).To(Equal(true))
+			Expect(vpcCIDR).To(Equal(fakeCIDR))
+
+			By("having a deployment owner reference")
+			Expect(len(awsConfigMap.OwnerReferences)).To(Equal(1))
+		})
+
+		AfterEach(func() {
+			err := k8sClient.Delete(ctx, &awsConfigMap)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("The configmap aws-data already exists", func() {
+		BeforeEach(func() {
+			err := k8sClient.Create(ctx, &configMap)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		When("aws data gathering runs", func() {
+			BeforeEach(func() {
+				err := gatherAndSaveData("http://"+testMockerAddr, fakeDeployment, k8sClient, context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should have updated the configmap", func() {
+				err := k8sClient.Get(ctx, tutils.GetResourceKey(&configMap), &configMap)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("adding VPC cidr key")
+				vpcCIDR, ok := configMap.Data[utils.CIDRKey]
+				Expect(ok).To(Equal(true))
+				Expect(vpcCIDR).To(Equal(fakeCIDR))
+
+				By("adding a deployment owner reference")
+				Expect(len(configMap.OwnerReferences)).To(Equal(1))
+			})
+		})
+
+		AfterEach(func() {
+			err := k8sClient.Delete(ctx, &configMap)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/cmd/awsDataGather/suite_test.go
+++ b/cmd/awsDataGather/suite_test.go
@@ -1,0 +1,124 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"net/http"
+
+	v1 "github.com/red-hat-storage/ocs-osd-deployer/api/v1alpha1"
+
+	"github.com/go-logr/logr"
+	// +kubebuilder:scaffold:imports
+)
+
+const (
+	testNamespace  = "default"
+	testMockerAddr = "localhost:8082"
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "AWS data gathering Suite")
+}
+
+var _ = BeforeSuite(func() {
+	done := make(chan interface{})
+	go func() {
+		logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+		var err error
+		testEnv = &envtest.Environment{}
+		cfg, err = testEnv.Start()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg).ToNot(BeNil())
+
+		// Setup client options
+		var options client.Options
+
+		options.Scheme = runtime.NewScheme()
+		utilruntime.Must(clientgoscheme.AddToScheme(options.Scheme))
+		utilruntime.Must(v1.AddToScheme(options.Scheme))
+
+		// Client to be use by the test code, using a non cached client
+		k8sClient, err = client.New(cfg, options)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(k8sClient).ToNot(BeNil())
+
+		go runIMDSv1MockServer(testMockerAddr, ctrl.Log.WithName("IMDSv1Mocker"))
+
+		close(done)
+	}()
+	Eventually(done, 60).Should(BeClosed())
+})
+
+var _ = AfterSuite(func() {
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+const (
+	macPath  = "/latest/meta-data/mac"
+	cidrPath = "/latest/meta-data/network/interfaces/macs/ff:ff:ff:ff:ff:ff/vpc-ipv4-cidr-block"
+	fakeMac  = "ff:ff:ff:ff:ff:ff"
+	fakeCIDR = "10.0.0.0/16"
+)
+
+func runIMDSv1MockServer(listenAddr string, log logr.Logger) {
+	server := &http.Server{Addr: listenAddr}
+
+	http.HandleFunc(macPath, func(writer http.ResponseWriter, req *http.Request) {
+		log.Info("Received request for mac address")
+		_, err := writer.Write([]byte(fakeMac))
+		if err != nil {
+			log.Error(err, "Failed to write response body")
+			writer.WriteHeader(http.StatusServiceUnavailable)
+		}
+	})
+
+	http.HandleFunc(cidrPath, func(writer http.ResponseWriter, req *http.Request) {
+		log.Info("Received request for vpc cidr")
+		_, err := writer.Write([]byte(fakeCIDR))
+		if err != nil {
+			log.Error(err, "Failed to write response body: %s")
+			writer.WriteHeader(http.StatusServiceUnavailable)
+		}
+	})
+
+	log.Info("Starting fake IMDS v1 server...")
+	err := server.ListenAndServe()
+	if err != nil && err != http.ErrServerClosed {
+		log.Error(err, "Failed to start fake IMDS v1 server")
+	}
+}

--- a/config/aws-data-gather/deployment.yaml
+++ b/config/aws-data-gather/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aws-data-gather
+spec:
+  selector:
+    matchLabels:
+      name: aws-data-gather
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: aws-data-gather
+    spec:
+      containers:
+      - command:
+        - /awsDataGather
+        image: controller:latest
+        name: aws-data-gather
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      serviceAccountName: aws-data-gather
+      hostNetwork: true

--- a/config/aws-data-gather/kustomization.yaml
+++ b/config/aws-data-gather/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+images:
+- name: controller
+  newName: ocs-osd-deployer
+  newTag: latest

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
+- ../aws-data-gather
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/rbac/aws_data_gather.yaml
+++ b/config/rbac/aws_data_gather.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-data-gather
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: aws-data-gather
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - create
+    - get
+    - update
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - get
+  - apiGroups:
+    - apps
+    resources:
+    - deployment/finalizers
+    verbs:
+    - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aws-data-gather
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aws-data-gather
+subjects:
+  - kind: ServiceAccount
+    name: aws-data-gather
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aws-data-gather
+rules:
+  - apiGroups:
+    - security.openshift.io
+    resources:
+    - securitycontextconstraints
+    resourceNames:
+    - hostnetwork
+    verbs:
+    - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-data-gather
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-data-gather
+subjects:
+- kind: ServiceAccount
+  name: aws-data-gather

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- aws_data_gather.yaml

--- a/controllers/managedocs_controller_test.go
+++ b/controllers/managedocs_controller_test.go
@@ -492,7 +492,7 @@ var _ = Describe("ManagedOCS controller", func() {
 		}
 		if shouldDMSSecretExist {
 			if hasSnitchUrl {
-				dmsSecret.Data["SNITCH_URL"] = []byte("test-url")
+				dmsSecret.Data["SNITCH_URL"] = []byte("https://nosnch.in/fake_url")
 			} else {
 				dmsSecret.Data["SNITCH_URL"] = []byte("")
 			}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -36,6 +36,7 @@ import (
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v1alpha1"
 	v1 "github.com/red-hat-storage/ocs-osd-deployer/api/v1alpha1"
+	"github.com/red-hat-storage/ocs-osd-deployer/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -229,6 +230,15 @@ var _ = BeforeSuite(func() {
 			"test-key": "test-value",
 		}
 		Expect(k8sClient.Create(ctx, rookConfigMap)).ShouldNot(HaveOccurred())
+
+		// Create the aws data config map
+		awsConfigMap := &corev1.ConfigMap{}
+		awsConfigMap.Name = utils.IMDSConfigMapName
+		awsConfigMap.Namespace = testPrimaryNamespace
+		awsConfigMap.Data = map[string]string{
+			utils.CIDRKey: "10.0.0.0/16",
+		}
+		Expect(k8sClient.Create(ctx, awsConfigMap)).ShouldNot(HaveOccurred())
 
 		// create a mock deplyer CSV
 		deployerCSV := &opv1a1.ClusterServiceVersion{}

--- a/tools/deploy-with-olm.sh
+++ b/tools/deploy-with-olm.sh
@@ -46,6 +46,7 @@ ALERT_SMTP_FROM_ADDR=${ALERT_SMTP_FROM_ADDR:-noreply-test@email.com}
 BUNDLE_FILE=${OUTPUT_DIR}/manifests/ocs-osd-deployer.clusterserviceversion.yaml
 CLUSTER_SIZE=${CLUSTER_SIZE:-1}
 ENABLE_MCG_FLAG=${ENABLE_MCG_FLAG:-false}
+SNITCH_URL=${SNITCH_URL:-https://nosnch.in/fake_url}
 
 #SMTP config variables
 [ -z "$NOTIFICATION_EMAIL" ] || NOTIFICATION_EMAIL_OPT="--from-literal notification-email-0=${NOTIFICATION_EMAIL}"


### PR DESCRIPTION
Provider clusters run storage pods on the host network namespace of their worker nodes. To properly set up the network policy, the machine CIDR must be known. In AWS, this can be determined by making a call to the IMDSv2 server that is available in any VPC. This PR creates a deployment to gather the needed data, and modifies the reconcilation loop to make use of the AWS data when setting up the network policies.

Signed-off-by: Renan Campos <rcampos@redhat.com>