### PR TITLE
get all PVs during consumer installation checks

### DIFF
--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -1835,7 +1835,7 @@ func (r *ManagedOCSReconciler) hasOCSVolumes() (bool, error) {
 
 	// get all the PVs
 	pvList := &corev1.PersistentVolumeList{}
-	if err := r.UnrestrictedClient.List(r.ctx, pvList, &client.ListOptions{Limit: int64(1)}); err != nil {
+	if err := r.UnrestrictedClient.List(r.ctx, pvList); err != nil {
 		return false, fmt.Errorf("unable to list persistent volumes: %v", err)
 	}
 


### PR DESCRIPTION
- An optimisation mentioned in #183 was wrongly applied to `hasOCSVolumes()`
- The original intention was to filter out a specific CR however PVs aren't individually identifiable during consumer uninstallation without their corresponding StorageClass info

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>