### PR TITLE
Final changes for separating ODF Control & Data Planes

### DIFF
--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -6,4 +6,4 @@ dependencies:
 - type: olm.package
   value:
     packageName: odf-operator
-    version: "4.10.5"
+    version: "4.10.7"

--- a/templates/providerstoragecluster.go
+++ b/templates/providerstoragecluster.go
@@ -34,10 +34,9 @@ const (
 	osdNodeLabel         = "node.ocs.openshift.io/osd"
 )
 
-var osdNodeSelector []corev1.PreferredSchedulingTerm = []corev1.PreferredSchedulingTerm{
-	{
-		Weight: int32(100),
-		Preference: corev1.NodeSelectorTerm{
+var osdNodeSelector *corev1.NodeSelector = &corev1.NodeSelector{
+	NodeSelectorTerms: []corev1.NodeSelectorTerm{
+		{
 			MatchExpressions: []corev1.NodeSelectorRequirement{
 				{
 					Key:      osdNodeLabel,
@@ -137,7 +136,7 @@ var ProviderStorageClusterTemplate = ocsv1.StorageCluster{
 			},
 			Placement: rook.Placement{
 				NodeAffinity: &corev1.NodeAffinity{
-					PreferredDuringSchedulingIgnoredDuringExecution: osdNodeSelector,
+					RequiredDuringSchedulingIgnoredDuringExecution: osdNodeSelector,
 				},
 				Tolerations: []corev1.Toleration{
 					osdToleration,
@@ -148,7 +147,7 @@ var ProviderStorageClusterTemplate = ocsv1.StorageCluster{
 			},
 			PreparePlacement: rook.Placement{
 				NodeAffinity: &corev1.NodeAffinity{
-					PreferredDuringSchedulingIgnoredDuringExecution: osdNodeSelector,
+					RequiredDuringSchedulingIgnoredDuringExecution: osdNodeSelector,
 				},
 				Tolerations: []corev1.Toleration{
 					osdToleration,

--- a/utils/resources.go
+++ b/utils/resources.go
@@ -66,11 +66,11 @@ var resourceRequirements = map[string]corev1.ResourceRequirements{
 	},
 	"prometheus": {
 		Limits: corev1.ResourceList{
-			"cpu":    resource.MustParse("450m"),
+			"cpu":    resource.MustParse("400m"),
 			"memory": resource.MustParse("250Mi"),
 		},
 		Requests: corev1.ResourceList{
-			"cpu":    resource.MustParse("450m"),
+			"cpu":    resource.MustParse("400m"),
 			"memory": resource.MustParse("250Mi"),
 		},
 	},


### PR DESCRIPTION
1. Bump ODF dependency from 4.10.5 to 4.10.7
2. Reduce prometheus cpu request by 50m shares
- in some of test scenarios prom fails to schedule during migration of
  existing clusters for a want of 2m, 30m & 100m shares on three nodes
- reducing by 50m shares would help prom to be schedulable on atleast
  two nodes
3. Revert "use preferred scheduling for osd-pods"
- due to MON not failing over to new nodes, OSDs are coming up on ODF
  control plane nodes

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>