### PR TITLE
Backport to v2.0

### DIFF
--- a/utils/resources.go
+++ b/utils/resources.go
@@ -97,11 +97,11 @@ var resourceRequirements = map[string]corev1.ResourceRequirements{
 	"rook-ceph-operator": {
 		Limits: corev1.ResourceList{
 			"cpu":    resource.MustParse("300m"),
-			"memory": resource.MustParse("200Mi"),
+			"memory": resource.MustParse("250Mi"),
 		},
 		Requests: corev1.ResourceList{
 			"cpu":    resource.MustParse("300m"),
-			"memory": resource.MustParse("200Mi"),
+			"memory": resource.MustParse("250Mi"),
 		},
 	},
 	"ocs-metrics-exporter": {


### PR DESCRIPTION
- Increase memory for rook-ceph operator to 250Mi