### PR TITLE
Update the dependency of ODF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # ===== Overridable Variables ===== #
 
 # Current Operator version
-VERSION ?= 2.1.2
-REPLACES ?= 2.1.1
+VERSION ?= 2.1.3
+REPLACES ?= 2.1.2
 
 # Default bundle image tag
 IMAGE_TAG_BASE ?= controller

--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -6,4 +6,4 @@ dependencies:
 - type: olm.package
   value:
     packageName: odf-operator
-    version: "4.11.12"
+    version: "4.11.13"


### PR DESCRIPTION
This PR includes two changes:

1. To update the dependency of ODF to 4.11.13 
2. To update the makefile for v2.1.3 rollout